### PR TITLE
Implement Predictions router and controller

### DIFF
--- a/Controllers/Predictions.js
+++ b/Controllers/Predictions.js
@@ -1,0 +1,24 @@
+const axios = require('axios');
+const { buildApiUrl } = require('../utils.js');
+
+const getPredictions = (req, res) => {
+  const options = {
+    command: 'predictions', 
+    route: req.params.route,
+    stopTag: req.params.stopTag
+  };
+
+  const url = buildApiUrl(options);
+  
+  axios.get(url)
+    .then(response => {
+      const data = response.data.predictions.direction.prediction;
+      const predictions = data.map(data => (data.minutes));
+      res.status(200).send(predictions);
+    })
+    .catch(err => {
+      res.status(400).send(err);
+    })
+};
+
+module.exports = getPredictions;

--- a/Routers/Predictions.js
+++ b/Routers/Predictions.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { getPredictions } = require('../Controllers/Predictions.js');
+const getPredictions = require('../Controllers/Predictions.js');
 
-router.get('/:stopId', getPredictions);
+router.get('/:route/:stopTag', getPredictions);
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -2,8 +2,8 @@ const express = require('express');
 const morgan = require('morgan');
 const cors = require('cors');
 
-const StationsRouter = require('Routers/Stations.js');
-const PredictionsRouter = require('Routers/Predictions.js');
+const StationsRouter = require('./Routers/Stations.js');
+const PredictionsRouter = require('./Routers/Predictions.js');
 
 const app = express();
 const PORT = process.env.PORT || 3000;

--- a/utils.js
+++ b/utils.js
@@ -1,11 +1,11 @@
 const FLAGS = require('./config.js');
 
 const buildApiUrl = options => {
-  const { command, agent = FLAGS.agents.sf, stopId, route } = options;
+  const { command, agent = FLAGS.agents.sf, stopTag, route } = options;
   if (command === undefined) throw new Error('ERROR: `command` param missing');
 
   if (command === FLAGS.commands.predictions) {
-    return `${FLAGS.root}?command=${command}&a=${agent}&stopId=${stopId}`;
+    return `${FLAGS.root}?command=${command}&a=${agent}&r=${route}&s=${stopTag}`;
   }
   
   if (command === FLAGS.commands.routes) {


### PR DESCRIPTION
@ecuyle  Please review the following PR.
Predictions router and controller exposes the /v1/api/predictions/:route/:stopTag endpoint to client users. Clients can expect to receive an array of ints representing the forecasted minutes a train is expected to arrive for a selected route (HTTP 200). An HTTP 400 will be sent on error.