### PR TITLE
 Fix bug with predictions endpoint

### DIFF
--- a/Controllers/Predictions.js
+++ b/Controllers/Predictions.js
@@ -11,14 +11,25 @@ const getPredictions = (req, res) => {
   const url = buildApiUrl(options);
   
   axios.get(url)
-    .then(response => {
-      const data = response.data.predictions.direction.prediction;
-      const predictions = data.map(data => (data.minutes));
-      res.status(200).send(predictions);
+    .then(({ data }) => {
+      const directions = data.predictions.direction;
+      const predictions = [];
+      if (Array.isArray(directions)) {
+        directions.forEach(direction => {
+          direction.prediction.forEach(prediction => {
+            predictions.push(prediction.minutes);
+          });
+        });
+      } else {
+        directions.prediction.forEach(prediction => {
+          predictions.push(prediction.minutes);
+        });  
+      }
+      res.status(200).send(predictions.sort());
     })
     .catch(err => {
       res.status(400).send(err);
-    })
+    });
 };
 
 module.exports = getPredictions;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node
+WORKDIR /app
+COPY . /app
+RUN npm install
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
NextBus's API endpoint for predictions changes datatypes depending
on trains available. Originally, we built our predictions endpoint
wrapper to expect objects to be returned from the NextBus API.
Refactor to handle arrays as a return value.