### PR TITLE
Fix bug with sorting of prediction estimates

### DIFF
--- a/Controllers/Predictions.js
+++ b/Controllers/Predictions.js
@@ -17,7 +17,7 @@ const getPredictions = (req, res) => {
       if (Array.isArray(directions)) {
         directions.forEach(direction => {
           direction.prediction.forEach(prediction => {
-            predictions.push(prediction.minutes);
+            predictions.push(parseInt(prediction.minutes));
           });
         });
       } else {
@@ -25,7 +25,9 @@ const getPredictions = (req, res) => {
           predictions.push(prediction.minutes);
         });  
       }
-      res.status(200).send(predictions.sort());
+      res.status(200).send(predictions.sort((a, b) => {
+        return a - b;
+      }));
     })
     .catch(err => {
       res.status(400).send(err);

--- a/Controllers/Predictions.js
+++ b/Controllers/Predictions.js
@@ -17,7 +17,7 @@ const getPredictions = (req, res) => {
       if (Array.isArray(directions)) {
         directions.forEach(direction => {
           direction.prediction.forEach(prediction => {
-            predictions.push(parseInt(prediction.minutes));
+            predictions.push(Number(prediction.minutes));
           });
         });
       } else {


### PR DESCRIPTION
Previously, was sorting a list of minutes (string), which returned
an incorrectly sorted string of estimated predictions. Now parse each
estimated into an int and sorted in ascending order.