### PR TITLE
Implement GET /v1/api/ghosttrain/:route endpoint

### DIFF
--- a/Controllers/Ghost.js
+++ b/Controllers/Ghost.js
@@ -1,0 +1,30 @@
+const axios = require('axios');
+const { buildApiUrl } = require('../utils.js');
+
+const checkGhostTrain = async function(req, res) {
+  // Inputs:
+  //   - route (String): Valid route tag (ie L, M, KT, J, N)
+  // Outputs:
+  //   - Success (HTTP 200): Boolean indicating if the estimates
+  //     for a given route are ghost trains. `true` indicates that
+  //     all estimates are ghost trains. `false` indicates that not
+  //     all estimates are ghost trains.
+  //   - Error (HTTP 400): Error message string
+  
+  const { route } = req.params;
+  const urlOptions = {
+    command: 'vehicleLocations',
+    route,
+  };
+  const url = buildApiUrl(urlOptions);
+  try {
+    const { data: { vehicle } } = await axios.get(url);
+    res.send(vehicle.length > 0);
+  } catch(e) {
+    res.status(400).send(e);
+  }
+};
+module.exports = {
+  checkGhostTrain
+};
+

--- a/Routers/Ghost.js
+++ b/Routers/Ghost.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { checkGhostTrain } = require('../Controllers/Ghost.js');
+
+router.get('/:route', checkGhostTrain);
+
+module.exports = router;

--- a/config.js
+++ b/config.js
@@ -6,6 +6,7 @@ module.exports = {
   commands: {
     predictions: 'predictions',
     routes: 'routeConfig',
+    vehloc: 'vehicleLocations',
   },
 };
 

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const cors = require('cors');
 const StationsRouter = require('./Routers/Stations.js');
 const PredictionsRouter = require('./Routers/Predictions.js');
 const InitDelayRouter = require('./Routers/InitDelay.js');
+const GhostRouter = require('./Routers/Ghost.js');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,7 @@ app.use(cors());
 app.use('/v1/api/stations', StationsRouter);
 app.use('/v1/api/predictions', PredictionsRouter);
 app.use('/v1/api/initDelay', InitDelayRouter);
+app.use('/v1/api/ghosttrain', GhostRouter);
 
 app.listen(PORT, err => {
   if (err) throw err;

--- a/utils.js
+++ b/utils.js
@@ -10,7 +10,11 @@ const buildApiUrl = options => {
   
   if (command === FLAGS.commands.routes) {
     return `${FLAGS.root}?command=${command}&a=${agent}&r=${route}`;
-  } 
+  }
+
+  if (command === FLAGS.commands.vehloc) {
+    return `${FLAGS.root}?command=${command}&a=${agent}&r=${route}`;
+  }
 
   throw new Error(`ERROR: 'command' param ${command} unsupported.`);
 };


### PR DESCRIPTION
@JackyLei94 Please review this PR.
Refer to commits for further details. In short, this PR implements the `GET /v1/api/ghosttrain/:route` endpoint. Clients can pass in a route tag to this endpoint to determine whether or not the current estimates for the given route are ghost trains. On success (HTTP 200), this endpoint will return true if all estimates ARE ghost trains. False will be returned if AT LEAST ONE estimate is NOT a ghost train. On error, a HTTP 400 will be sent with the related error message.